### PR TITLE
Fix IDL errors (mainly RTCIceParameters)

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,29 +91,17 @@
     <code><a>RTCIceTransport</a>.start()</code> method, and the absence of
     an <code>RTCIceGatherer</code> object.</p>
     <section id="rtciceparameters*">
-    <h3><dfn>RTCIceParameters</dfn> Dictionary</h3>
-      <p>The <code>RTCIceParameters</code> dictionary includes the ICE username
-      fragment and password and other ICE-related parameters.</p>
+    <h3><dfn>RTCIceParameters</dfn> Extensions</h3>
+      <p>The <code>RTCIceParameters</code> dictionary is extended with an
+      <code><a>iceLite</a></code> member.</p>
       <div>
-<pre class="idl">dictionary RTCIceParameters {
-             required DOMString usernameFragment;
-             required DOMString password;
+<pre class="idl">partial dictionary RTCIceParameters {
              boolean   iceLite;
 };</pre>
         <section>
           <h2>Dictionary <a class="idlType">RTCIceParameters</a> Members</h2>
           <dl data-link-for="RTCIceParameters" data-dfn-for="RTCIceParameters" class=
           "dictionary-members">
-            <dt><dfn data-idl><code>usernameFragment</code></dfn> of type <span class=
-            "idlMemberType">DOMString</span>, required</dt>
-            <dd>
-              <p>ICE username fragment.</p>
-            </dd>
-            <dt><dfn data-idl><code>password</code></dfn> of type <span class=
-            "idlMemberType">DOMString</span>, required</dt>
-            <dd>
-              <p>ICE password.</p>
-            </dd>
             <dt><dfn data-idl><code>iceLite</code></dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
@@ -164,9 +152,9 @@
 partial interface RTCIceTransport {
     constructor();
     void                      gather (optional RTCIceGatherOptions options = {});
-    void                      start (RTCIceParameters remoteParameters, optional RTCIceRole role = "controlled");
+    void                      start (optional RTCIceParameters remoteParameters = {}, optional RTCIceRole role = "controlled");
     void                      stop ();
-    void                      addRemoteCandidate (RTCIceCandidateInit remoteCandidate);
+    void                      addRemoteCandidate (optional RTCIceCandidateInit remoteCandidate = {});
                     attribute EventHandler        onerror;
                     attribute EventHandler        onicecandidate;
 };</pre>


### PR DESCRIPTION
RTCIceParameters is made a partial dictionary, with the consequence
that there are no required members. Where RTCIceParameters or
RTCIceParameters is used as an argument, the arguments are made
optional.

Fixes https://github.com/w3c/webrtc-ice/issues/35.