### PR TITLE
Fix autolink to iceLite definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <section id="rtciceparameters*">
     <h3><dfn>RTCIceParameters</dfn> Extensions</h3>
       <p>The {{RTCIceParameters}} dictionary is extended with an
-      <code><a>iceLite</a></code> member.</p>
+      {{RTCIceParameters/iceLite}} member.</p>
       <div>
 <pre class="idl">partial dictionary RTCIceParameters {
              boolean   iceLite;
@@ -74,7 +74,7 @@
           <h2>Dictionary {{RTCIceParameters}} Members</h2>
           <dl data-link-for="RTCIceParameters" data-dfn-for="RTCIceParameters" class=
           "dictionary-members">
-            <dt><dfn data-idl><code>iceLite</code></dfn> of type <span class=
+            <dt><dfn data-idl>iceLite</dfn> of type <span class=
             "idlMemberType">boolean</span></dt>
             <dd>
               <p>If only ICE-lite is supported (<code>true</code>) or not

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
     {{RTCIceTransport.start()}} method, and the absence of
     an <code>RTCIceGatherer</code> object.</p>
     <section id="rtciceparameters*">
-    <h3><dfn>RTCIceParameters</dfn> Extensions</h3>
+    <h3>{{RTCIceParameters}} Extensions</h3>
       <p>The {{RTCIceParameters}} dictionary is extended with an
       {{RTCIceParameters/iceLite}} member.</p>
       <div>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-ice/pull/42.html" title="Last updated on Mar 1, 2021, 11:08 AM UTC (106f32d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webrtc-ice/42/85fbeb2...106f32d.html" title="Last updated on Mar 1, 2021, 11:08 AM UTC (106f32d)">Diff</a>